### PR TITLE
Fixed song not loading

### DIFF
--- a/SLAM/Form1.vb
+++ b/SLAM/Form1.vb
@@ -447,7 +447,7 @@ Public Class Form1
     End Function
 
     Private Function recog(ByVal str As String, ByVal reg As String) As String
-        Dim keyd As Match = Regex.Match(str, reg)
+        Dim keyd As Match = Regex.Match(str, reg, RegexOptions.IgnoreCase) 'RegexOptions.IgnoreCase because bind could be saved as lowercase
         Return (keyd.Groups(1).ToString)
     End Function
 


### PR DESCRIPTION
This option helped me to fix the issue that songs have not been not loaded. 

Example:
Relay Key = O
slam_relay.cfg: ...bind "o" "2"...

This line was not recognized by the recog function as "o" != "O". RegexOptions.IgnoreCase fixed this.