### PR TITLE
Fixed start button pressed in quick succession causing issues (#94)

### DIFF
--- a/SLAM/Form1.vb
+++ b/SLAM/Form1.vb
@@ -349,7 +349,9 @@ Public Class Form1
         StartButton.Enabled = True
         TrackList.Enabled = True
         SetVolumeToolStripMenuItem.Enabled = True
-        PollRelayWorker.RunWorkerAsync(GetCurrentGame)
+        If PollRelayWorker.IsBusy <> True Then
+            PollRelayWorker.RunWorkerAsync(GetCurrentGame)
+        End If
     End Sub
 
     Private Sub StopPoll()


### PR DESCRIPTION
Fixed start button pressed in quick succession causing issues (#94)

By adding a check for BackgroundWorker busy state